### PR TITLE
Update time to ros time now

### DIFF
--- a/livox_ros_driver/debian/changelog
+++ b/livox_ros_driver/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-livox-ros-driver (2.0.2-0bionic) bionic; urgency=medium
+
+  * Update lidar frame time to ros time now. 
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Tue, 09 Nov 2021 10:55:02 -0500
+
 ros-melodic-livox-ros-driver (2.0.1-0bionic) bionic; urgency=high
 
   * Added dependency for livox-sdk

--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -203,7 +203,7 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
     }
     /** Use the first packet timestamp as pointcloud2 msg timestamp */
     if (!published_packet) {
-      cloud.header.stamp = ros::Time(timestamp / 1000000000.0);
+      cloud.header.stamp = ros::Time::now();
     }
     uint32_t single_point_num = storage_packet.point_num * echo_num;
 
@@ -242,7 +242,7 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
     p_publisher->publish(cloud);
   } else {
     if (bag_ && enable_lidar_bag_) {
-      bag_->write(p_publisher->getTopic(), ros::Time(timestamp / 1000000000.0),
+      bag_->write(p_publisher->getTopic(), ros::Time::now(),
           cloud);
     }
   }
@@ -343,7 +343,7 @@ uint32_t Lddc::PublishPointcloudData(LidarDataQueue *queue, uint32_t packet_num,
     p_publisher->publish(cloud);
   } else {
     if (bag_ && enable_lidar_bag_) {
-      bag_->write(p_publisher->getTopic(), ros::Time(timestamp / 1000000000.0),
+      bag_->write(p_publisher->getTopic(), ros::Time::now(),
           cloud);
     }
   }
@@ -425,7 +425,7 @@ uint32_t Lddc::PublishCustomPointcloud(LidarDataQueue *queue,
       livox_msg.timebase = timestamp;
       packet_offset_time = 0;
       /** convert to ros time stamp */
-      livox_msg.header.stamp = ros::Time(timestamp / 1000000000.0);
+      livox_msg.header.stamp = ros::Time::now();
     } else {
       packet_offset_time = (uint32_t)(timestamp - livox_msg.timebase);
     }
@@ -467,7 +467,7 @@ uint32_t Lddc::PublishCustomPointcloud(LidarDataQueue *queue,
     p_publisher->publish(livox_msg);
   } else {
     if (bag_ && enable_lidar_bag_) {
-      bag_->write(p_publisher->getTopic(), ros::Time(timestamp / 1000000000.0),
+      bag_->write(p_publisher->getTopic(), ros::Time::now(),
           livox_msg);
     }
   }
@@ -494,7 +494,7 @@ uint32_t Lddc::PublishImuData(LidarDataQueue *queue, uint32_t packet_num,
   timestamp = GetStoragePacketTimestamp(&storage_packet, data_source);
   if (timestamp >= 0) {
     imu_data.header.stamp =
-        ros::Time(timestamp / 1000000000.0);  // to ros time stamp
+        ros::Time::now();  // to ros time stamp
   }
 
   uint8_t point_buf[2048];
@@ -516,7 +516,7 @@ uint32_t Lddc::PublishImuData(LidarDataQueue *queue, uint32_t packet_num,
     p_publisher->publish(imu_data);
   } else {
     if (bag_ && enable_imu_bag_) {
-      bag_->write(p_publisher->getTopic(), ros::Time(timestamp / 1000000000.0),
+      bag_->write(p_publisher->getTopic(), ros::Time::now(),
           imu_data);
     }
   }


### PR DESCRIPTION
This PR solves [18809](https://app.shortcut.com/greenzie/story/18809/p5-fix-livox-lidar-timeout)

This PR solves the issue where the lidar data was unusable because the lidar driver used a different time than ros time now.